### PR TITLE
path replace bug when uploading to the same directory has been fixed

### DIFF
--- a/lib/AzureStorageManager.js
+++ b/lib/AzureStorageManager.js
@@ -108,10 +108,13 @@ class AzureStorageManager {
       if (fs.lstatSync(newPath).isDirectory()) {
         await this.#folderScanner(newPath, root);
       } else {
-        const url = newPath
-          .replace(root, "")
-          .replace(/\\/g, "/")
-          .replace(/^\//i, ""); // replace only starts with /
+        let url = newPath;
+        if (url.startsWith(root)) { // -f . usage causes file extension change
+          url = url.replace(root, '');
+        }
+        url = url
+          .replace(/\\/g, '/')
+          .replace(/^\//i, ''); // replace only starts with /
         const mimetype = mime.contentType(path.extname(newPath));
         this.#fileList.push({ path: newPath, url, mimetype });
       }

--- a/lib/AzureStorageManager.js
+++ b/lib/AzureStorageManager.js
@@ -111,7 +111,7 @@ class AzureStorageManager {
         const url = newPath
           .replace(root, "")
           .replace(/\\/g, "/")
-          .replace(/[/]/i, "");
+          .replace(/^\//i, ""); // replace only starts with /
         const mimetype = mime.contentType(path.extname(newPath));
         this.#fileList.push({ path: newPath, url, mimetype });
       }


### PR DESCRIPTION
When working on the same directory that you want to upload, some "/"s disappear from the path.